### PR TITLE
Added default creation delegate to AutoDefaultDictionary

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -39,7 +39,7 @@ dotnet_analyzer_diagnostic.severity = warning
 indent_size = 4
 csharp_using_directive_placement = outside_namespace:warning
 csharp_prefer_simple_using_statement = false:silent
-csharp_prefer_braces = true:error
+csharp_prefer_braces = true:warning
 csharp_style_namespace_declarations = file_scoped:warning
 csharp_prefer_system_threading_lock = true:suggestion
 csharp_style_expression_bodied_methods = true:suggestion
@@ -50,7 +50,6 @@ csharp_style_expression_bodied_indexers = true:warning
 csharp_style_expression_bodied_accessors = true:warning
 csharp_style_expression_bodied_lambdas = true:warning
 csharp_style_expression_bodied_local_functions = true:warning
-csharp_space_around_binary_operators = before_and_after
 csharp_style_throw_expression = true:warning
 csharp_style_prefer_null_check_over_type_check = true:warning
 csharp_prefer_simple_default_expression = true:warning
@@ -127,7 +126,6 @@ indent_style = tab
 # https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/language-rules#net-style-rules
 [*.{cs,csx,cake,vb,vbx}]
 
-
 # Non-private static fields are PascalCase
 dotnet_naming_rule.non_private_static_fields_should_be_pascal_case.severity = warning
 dotnet_naming_rule.non_private_static_fields_should_be_pascal_case.style = non_private_static_field_style
@@ -197,6 +195,9 @@ dotnet_diagnostic.IDE0071.severity = warning
 
 # Allow multiple blank lines
 dotnet_diagnostic.IDE2000.severity = silent
+
+dotnet_diagnostic.IDE0055.severity = none
+
 
 # All public/protected/protected_internal constant fields must be PascalCase
 # https://docs.microsoft.com/dotnet/standard/design-guidelines/field
@@ -1993,9 +1994,7 @@ dotnet_diagnostic.IDE0073.severity = warning
 file_header_template = unset
 
 # Fix formatting
-#dotnet_diagnostic.IDE0055.severity = warning
-dotnet_diagnostic.IDE0055.severity = silent
-
+dotnet_diagnostic.IDE0055.severity = warning
 
 # Organize usings
 dotnet_separate_import_directive_groups = false

--- a/.editorconfig
+++ b/.editorconfig
@@ -36,7 +36,49 @@ dotnet_analyzer_diagnostic.severity = warning
 
 # Visual Studio XML Project Files
 [*.{csproj,vbproj,vcxproj,vcxproj.filters,proj,projitems,shproj}]
-indent_size = 2
+indent_size = 4
+csharp_using_directive_placement = outside_namespace:warning
+csharp_prefer_simple_using_statement = false:silent
+csharp_prefer_braces = true:error
+csharp_style_namespace_declarations = file_scoped:warning
+csharp_prefer_system_threading_lock = true:suggestion
+csharp_style_expression_bodied_methods = true:suggestion
+csharp_style_expression_bodied_constructors = true:warning
+csharp_style_expression_bodied_operators = true:warning
+csharp_style_expression_bodied_properties = true:warning
+csharp_style_expression_bodied_indexers = true:warning
+csharp_style_expression_bodied_accessors = true:warning
+csharp_style_expression_bodied_lambdas = true:warning
+csharp_style_expression_bodied_local_functions = true:warning
+csharp_space_around_binary_operators = before_and_after
+csharp_style_throw_expression = true:warning
+csharp_style_prefer_null_check_over_type_check = true:warning
+csharp_prefer_simple_default_expression = true:warning
+csharp_style_prefer_local_over_anonymous_function = true:suggestion
+csharp_style_prefer_index_operator = true:warning
+csharp_style_prefer_range_operator = true:warning
+csharp_style_implicit_object_creation_when_type_is_apparent = true:warning
+csharp_style_prefer_tuple_swap = true:suggestion
+csharp_style_inlined_variable_declaration = true:warning
+csharp_style_deconstructed_variable_declaration = true:warning
+csharp_style_unused_value_assignment_preference = discard_variable:suggestion
+csharp_style_unused_value_expression_statement_preference = discard_variable:suggestion
+csharp_prefer_static_local_function = true:warning
+csharp_prefer_static_anonymous_function = true:suggestion
+csharp_style_prefer_readonly_struct = true:suggestion
+csharp_style_allow_embedded_statements_on_same_line_experimental = true:silent
+csharp_style_allow_blank_lines_between_consecutive_braces_experimental = true:silent
+csharp_style_allow_blank_line_after_colon_in_constructor_initializer_experimental = true:silent
+csharp_style_conditional_delegate_call = true:warning
+csharp_style_prefer_switch_expression = true:warning
+csharp_style_prefer_pattern_matching = true:warning
+csharp_style_pattern_matching_over_is_with_cast_check = true:warning
+csharp_style_pattern_matching_over_as_with_null_check = true:suggestion
+csharp_style_prefer_not_pattern = true:warning
+csharp_style_prefer_extended_property_pattern = true:suggestion
+csharp_style_var_for_built_in_types = true:warning
+csharp_style_var_when_type_is_apparent = true:warning
+csharp_style_var_elsewhere = true:warning
 
 # XML Configuration Files
 [*.{props,targets,ruleset,config,nuspec,resx,vsixmanifest,vsct,xml,stylecop}]
@@ -84,6 +126,7 @@ indent_style = tab
 # .NET Style Rules
 # https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/language-rules#net-style-rules
 [*.{cs,csx,cake,vb,vbx}]
+
 
 # Non-private static fields are PascalCase
 dotnet_naming_rule.non_private_static_fields_should_be_pascal_case.severity = warning
@@ -1950,7 +1993,9 @@ dotnet_diagnostic.IDE0073.severity = warning
 file_header_template = unset
 
 # Fix formatting
-dotnet_diagnostic.IDE0055.severity = warning
+#dotnet_diagnostic.IDE0055.severity = warning
+dotnet_diagnostic.IDE0055.severity = silent
+
 
 # Organize usings
 dotnet_separate_import_directive_groups = false
@@ -2430,7 +2475,7 @@ visual_basic_preferred_modifier_order = Partial, Default, Private, Protected, Pu
 # Code-block preferences
 csharp_prefer_braces = true: error
 csharp_prefer_simple_using_statement = false:silent
-dotnet_style_prefer_collection_expression = true:suggestion
+dotnet_style_prefer_collection_expression = when_types_exactly_match:suggestion
 
 # C# Style Rules
 # https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/language-rules#c-style-rules

--- a/.gitignore
+++ b/.gitignore
@@ -398,3 +398,5 @@ FodyWeavers.xsd
 *.sln.iml
 /.cr
 /AppBin
+/source/NDependOut/SourceFiles.zip
+/source/NDependOut/2022_05/01_10_09/SourceFiles.zip

--- a/source/NDependOut/2022_05/01_10_09/SourceFiles.zip
+++ b/source/NDependOut/2022_05/01_10_09/SourceFiles.zip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:eadbf464f06d786e460d3cb97bd5e41077859339a2c3835cc16f787a3fc15c14
-size 65848

--- a/source/NDependOut/SourceFiles.zip
+++ b/source/NDependOut/SourceFiles.zip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:eadbf464f06d786e460d3cb97bd5e41077859339a2c3835cc16f787a3fc15c14
-size 65848

--- a/source/Unit Tests/dotNetTips.Spargine.Core.Tests/Serialization/JsonSerializationTests.cs
+++ b/source/Unit Tests/dotNetTips.Spargine.Core.Tests/Serialization/JsonSerializationTests.cs
@@ -111,7 +111,8 @@ public class JsonSerializationTests
 		Assert.IsTrue(string.IsNullOrEmpty(json) is false);
 
 		//Deserialize
-		var serializedPerson = JsonSerialization.Deserialize<Person<Address>>(Resources.JsonPersonProper);
+//		var serializedPerson = JsonSerialization.Deserialize<Person<Address>>(Resources.JsonPersonProper);
+		var serializedPerson = JsonSerialization.Deserialize<Person<Address>>(json);
 
 		Assert.IsNotNull(serializedPerson);
 	}

--- a/source/dotNetTips.Spargine.8.Core/Collections/Generic/AutoDefaultDictionary.cs
+++ b/source/dotNetTips.Spargine.8.Core/Collections/Generic/AutoDefaultDictionary.cs
@@ -30,29 +30,38 @@ public class AutoDefaultDictionary<TKey, TValue> : Dictionary<TKey, TValue>, ISe
 		where TValue : notnull
 {
 	/// <summary>
-	/// The default value to return when a key is not found in the dictionary.
+	/// The delegate to run when a key is not found in the dictionary.  Is given the unknown key as an argument, and must return the value for that key
 	/// </summary>
-	private readonly TValue _defaultValue;
+	private readonly Func<TKey, TValue> _onMissingKey;
+
 
 	/// <summary>
 	/// Initializes a new instance of the <see cref="AutoDefaultDictionary{TKey, TValue}"/> class with the default value for <typeparamref name="TValue"/>.
 	/// </summary>
 	[Information(UnitTestStatus = UnitTestStatus.Completed, Status = Status.Available)]
-	public AutoDefaultDictionary() => this._defaultValue = default;
+	public AutoDefaultDictionary() => this._onMissingKey = key => throw new KeyNotFoundException($"The given key '{key}' was not present in the dictionary.");
+
+	/// <summary>
+	/// Initializes a new instance of the <see cref="AutoDefaultDictionary{TKey, TValue}"/> class calling the given delegate when the key is not present.
+	/// </summary>
+	/// <param name="onMissingKey"></param>
+	public AutoDefaultDictionary(Func<TKey, TValue> onMissingKey) => this._onMissingKey = onMissingKey;
+
+
 
 	/// <summary>
 	/// Initializes a new instance of the <see cref="AutoDefaultDictionary{TKey, TValue}"/> class with the specified default value for <typeparamref name="TValue"/>.
 	/// </summary>
 	/// <param name="defaultValue">The default value to return when a key is not found in the dictionary.</param>
 	[Information(UnitTestStatus = UnitTestStatus.Completed, Status = Status.Available)]
-	public AutoDefaultDictionary(TValue defaultValue) => this._defaultValue = defaultValue;
+	public AutoDefaultDictionary(TValue defaultValue) => this._onMissingKey = _ =>  defaultValue;
 
 	/// <summary>
 	/// Initializes a new instance of the <see cref="AutoDefaultDictionary{TKey, TValue}"/> class with the specified comparer.
 	/// </summary>
 	/// <param name="comparer">The comparer to use when comparing keys.</param>
 	[Information(UnitTestStatus = UnitTestStatus.Completed, Status = Status.Available)]
-	public AutoDefaultDictionary(IEqualityComparer<TKey> comparer) : base(comparer) => this._defaultValue = default;
+	public AutoDefaultDictionary(IEqualityComparer<TKey> comparer) : base(comparer) => this._onMissingKey = _ =>  default;
 
 	/// <summary>
 	/// Initializes a new instance of the <see cref="AutoDefaultDictionary{TKey, TValue}"/> class with the specified dictionary and default value.
@@ -60,7 +69,7 @@ public class AutoDefaultDictionary<TKey, TValue> : Dictionary<TKey, TValue>, ISe
 	/// <param name="dictionary">The dictionary to initialize with.</param>
 	/// <param name="defaultValue">The default value to return when a key is not found in the dictionary.</param>
 	[Information(UnitTestStatus = UnitTestStatus.Completed, Status = Status.Available)]
-	public AutoDefaultDictionary(IDictionary<TKey, TValue> dictionary, TValue defaultValue) : base(dictionary) => this._defaultValue = defaultValue;
+	public AutoDefaultDictionary(IDictionary<TKey, TValue> dictionary, TValue defaultValue) : base(dictionary) => this._onMissingKey = _ => defaultValue;
 
 	/// <summary>
 	/// Initializes a new instance of the <see cref="AutoDefaultDictionary{TKey, TValue}"/> class with the specified key-value pair collection and default value.
@@ -68,7 +77,7 @@ public class AutoDefaultDictionary<TKey, TValue> : Dictionary<TKey, TValue>, ISe
 	/// <param name="keyValuePairs">The key-value pairs to initialize with.</param>
 	/// <param name="defaultValue">The default value to return when a key is not found in the dictionary.</param>
 	[Information(UnitTestStatus = UnitTestStatus.Completed, Status = Status.Available)]
-	public AutoDefaultDictionary(IEnumerable<KeyValuePair<TKey, TValue>> keyValuePairs, TValue defaultValue) : base(keyValuePairs.ToDictionary(kvp => kvp.Key, kvp => kvp.Value)) => this._defaultValue = defaultValue;
+	public AutoDefaultDictionary(IEnumerable<KeyValuePair<TKey, TValue>> keyValuePairs, TValue defaultValue) : base(keyValuePairs.ToDictionary(kvp => kvp.Key, kvp => kvp.Value)) => this._onMissingKey = _ => defaultValue;
 
 	/// <summary>
 	/// Initializes a new instance of the <see cref="AutoDefaultDictionary{TKey, TValue}"/> class with the specified default value and comparer.
@@ -76,7 +85,7 @@ public class AutoDefaultDictionary<TKey, TValue> : Dictionary<TKey, TValue>, ISe
 	/// <param name="defaultValue">The default value to return when a key is not found in the dictionary.</param>
 	/// <param name="comparer">The comparer to use when comparing keys.</param>
 	[Information(UnitTestStatus = UnitTestStatus.Completed, Status = Status.Available)]
-	public AutoDefaultDictionary(TValue defaultValue, IEqualityComparer<TKey> comparer) : base(comparer) => this._defaultValue = defaultValue;
+	public AutoDefaultDictionary(TValue defaultValue, IEqualityComparer<TKey> comparer) : base(comparer) => this._onMissingKey = _ => defaultValue;
 
 	/// <summary>
 	/// Gets or sets the value associated with the specified key. If the key does not exist, the default value is returned and added to the dictionary.
@@ -91,7 +100,7 @@ public class AutoDefaultDictionary<TKey, TValue> : Dictionary<TKey, TValue>, ISe
 		{
 			if (!this.TryGetValue(key, out var value))
 			{
-				value = this._defaultValue;
+				value = this._onMissingKey(key);
 				this.Add(key, value);
 			}
 

--- a/source/dotNetTips.Spargine.8.Core/DotNetTips.Spargine.8.Core.csproj
+++ b/source/dotNetTips.Spargine.8.Core/DotNetTips.Spargine.8.Core.csproj
@@ -73,7 +73,7 @@
 	<TreatWarningsAsErrors>False</TreatWarningsAsErrors>
 	<CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
 	<Optimize>false</Optimize>
-	<NoWarn />
+	<NoWarn>IDE0055</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
@@ -83,7 +83,7 @@
 	<TreatWarningsAsErrors>False</TreatWarningsAsErrors>
 	<WarningLevel>9999</WarningLevel>
 	<Optimize>true</Optimize>
-	<NoWarn />
+	<NoWarn>IDE0055</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/source/dotNetTips.Spargine.8.Extensions/DotNetTips.Spargine.8.Extensions.csproj
+++ b/source/dotNetTips.Spargine.8.Extensions/DotNetTips.Spargine.8.Extensions.csproj
@@ -80,6 +80,22 @@
 	<WarningsAsErrors />
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net8.0|AnyCPU'">
+    <NoWarn>1701;1702; IDE0055</NoWarn>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net9.0|AnyCPU'">
+    <NoWarn>1701;1702; IDE0055</NoWarn>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net8.0|AnyCPU'">
+    <NoWarn>1701;1702; IDE0055</NoWarn>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net9.0|AnyCPU'">
+    <NoWarn>1701;1702; IDE0055</NoWarn>
+  </PropertyGroup>
+
   <ItemGroup>
     <None Remove="dotNetTips-Spargine-8-Logo.png" />
   </ItemGroup>

--- a/source/dotNetTips.Spargine.8.Tester/DotNetTips.Spargine.8.Tester.csproj
+++ b/source/dotNetTips.Spargine.8.Tester/DotNetTips.Spargine.8.Tester.csproj
@@ -85,6 +85,26 @@
 	<DebugType>embedded</DebugType>
   </PropertyGroup>
 
+
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net8.0|AnyCPU'">
+    <NoWarn>1701;1702; IDE0055</NoWarn>
+  </PropertyGroup>
+
+
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net9.0|AnyCPU'">
+    <NoWarn>1701;1702; IDE0055</NoWarn>
+  </PropertyGroup>
+
+
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net8.0|AnyCPU'">
+    <NoWarn>1701;1702; IDE0055</NoWarn>
+  </PropertyGroup>
+
+
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net9.0|AnyCPU'">
+    <NoWarn>1701;1702; IDE0055</NoWarn>
+  </PropertyGroup>
+
   <ItemGroup>
 	<None Include="..\..\README.md">
 	  <Pack>true</Pack>

--- a/source/dotNetTips.Spargine.8/DotNetTips.Spargine.8.csproj
+++ b/source/dotNetTips.Spargine.8/DotNetTips.Spargine.8.csproj
@@ -75,6 +75,22 @@
 		<TreatWarningsAsErrors>True</TreatWarningsAsErrors>
 	</PropertyGroup>
 
+	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net8.0|AnyCPU'">
+	  <NoWarn>1701;1702; IDE0055</NoWarn>
+	</PropertyGroup>
+
+	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net9.0|AnyCPU'">
+	  <NoWarn>1701;1702; IDE0055</NoWarn>
+	</PropertyGroup>
+
+	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net8.0|AnyCPU'">
+	  <NoWarn>1701;1702; IDE0055</NoWarn>
+	</PropertyGroup>
+
+	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net9.0|AnyCPU'">
+	  <NoWarn>1701;1702; IDE0055</NoWarn>
+	</PropertyGroup>
+
 	<ItemGroup>
 	  <None Remove="dotNetTips-Spargine-8-Logo.png" />
 	</ItemGroup>


### PR DESCRIPTION
AutoDefaultDictionary is a nice idea, but doesn't go far enough.  It allows only one default value for all undefined keys.  I've expanded this by allowing the user to provide a Func<TKey, TValue> delegate which is run when an unknown key is used.

This allows code like this:  `var dictionary = new AutoDefaultDictionary<int, double>(key => Math.Sqrt(key));`
or even
`var peopleCache = new AutoDefaultDictionary<int, Person>(key => _personRepository.GetPerson(key));`

The original behavior can be duplicated by:
`var dictionary = new AutoDefaultDictionary<int, double>( _ => default);`
BUT I've already modified the existing ctors to do that automatically.

I've added a new ctor:
`	public AutoDefaultDictionary(Func<TKey, TValue> onMissingKey);`

There is one bit of breaking change.  I've made the default ctor (no arguments), throw an exception like the standard Dictionary, because I feel this should be a drop-in replacement for that.

I've added unit tests for the changes.

(I also had to hide error IDE0055 because it was preventing compilation even before I touched it)

